### PR TITLE
Slack thread enhancements

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1166,6 +1166,9 @@ class SlackChannel(object):
             mk = self.messages.keys()
             mk.sort()
             for k in mk[:SCROLLBACK_SIZE]:
+                msg_to_delete = self.messages[k]
+                if msg_to_delete.hash:
+                    del self.hashed_messages[msg_to_delete.hash]
                 del self.messages[k]
     def change_message(self, ts, text=None, suffix=None):
         ts = SlackTS(ts)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1565,6 +1565,10 @@ class SlackThreadChannel(object):
             w.buffer_set(self.channel_buffer, "localvar_set_type", 'channel')
             w.buffer_set(self.channel_buffer, "localvar_set_channel", self.formatted_name())
             w.buffer_set(self.channel_buffer, "short_name", self.formatted_name(style="sidebar", enable_color=True))
+            time_format = w.config_string(w.config_get("weechat.look.buffer_time_format"))
+            parent_time = time.localtime(SlackTS(self.parent_message.ts).major)
+            topic = '{} {} | {}'.format(time.strftime(time_format, parent_time), self.parent_message.sender, self.parent_message.render()	)
+            w.buffer_set(self.channel_buffer, "title", topic.encode('utf-8'))
 
             #self.eventrouter.weechat_controller.set_refresh_buffer_list(True)
 


### PR DESCRIPTION
* Use first few hexdigits of sha1(thread_ts) instead of thread_ts as the thread identifier
  - sha1s of similar timestamps are different, so there's less typing for the user
  - the number of hexdigits starts at 3 and goes up when collisions are detected (unlikely)
  - the `/thread` command works with hashes as well as timestamps
* Display the original message that started the thread in the thread's topic

This is just an initial version, lemme know what I should change.
I guess I'll have to make things a bit more configurable.