### PR TITLE
Translate slack formatting codes to/from IRC formatting codes

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2217,6 +2217,10 @@ def render(message_json, team, channel, force=False):
         text = text.replace("&lt;", "<")
         text = text.replace("&gt;", ">")
         text = text.replace("&amp;", "&")
+        text = re.sub(r'(^| )\*([^*]+)\*([^a-zA-Z0-9_]|$)',
+                      r'\1{}\2{}\3'.format(w.color('bold'), w.color('-bold')), text)
+        text = re.sub(r'(^| )_([^_]+)_([^a-zA-Z0-9_]|$)',
+                      r'\1{}\2{}\3'.format(w.color('underline'), w.color('-underline')), text)
 
         if type(text) is not unicode:
             text = text.decode('UTF-8', 'replace')
@@ -2237,7 +2241,7 @@ def linkify_text(message, team, channel):
     # function is only called on message send..
     usernames = team.get_username_map()
     channels = team.get_channel_map()
-    message = message.split(' ')
+    message = message.replace('\x02', '*').replace('\x1F', '_').split(' ')
     for item in enumerate(message):
         targets = re.match('.*([@#])([\w.-]+[\w. -])(\W*)', item[1])
         #print targets


### PR DESCRIPTION
Specifically, this translates * into bold and _ into underline.

It tries to be at least somewhat smart about it, looking for formatting characters at the leading and trailing edges of words so that someone saying, e.g., "foo_bar" doesn't trigger it.

Outgoing messages are also properly converted rather than sending the raw control characters to slack.

Signed-off-by: Ben Kelly <btk@google.com>